### PR TITLE
0.5.5

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,7 @@
+### 0.5.5
+* Replaced `node-cache` with `elasticsearch-cache` internal library for `getReferrer` request.
+* Cleaned up `package.json`, removed `md5` and `node-cache` npm packages since it not using anymore. 
+
 ### 0.5.4
 * Added condition to prevent manipulates with cache without `GIT_NAME` and `GIT_BRANCH` ENVs.
 * Added `GIT_NAME` and `GIT_BRANCH` environment variables to `circleci` config. 

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,7 +197,7 @@ Object.defineProperties( module.exports, {
 
             urlParts.brand = brand ? brand.uniqueID : null;
 
-            elasticSearchCache.set(cacheKey, agent, 60 * 60).then(result => {
+            elasticSearchCache.set(cacheKey, urlParts, 60 * 60).then(result => {
               debug('Successfully stored cache doc [%s]', cacheKey);
             }, error => {
               console.error(error);

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,15 +4,12 @@
 let debug = require( 'debug' )('boxmls-utility'),
   _ = require( 'lodash'),
   url = require('url'),
-  md5 = require('md5'),
   colors = require('colors'),
   crypto = require('crypto'),
   Cache = require('async-disk-cache'),
   cache = new Cache('errors'),
   async = require('async'),
   Slack = require( 'slack-node'),
-  NodeCache = require( "node-cache" ),
-  myCache = new NodeCache(),
   firebase = require('boxmls-firebase-admin');
 
 Object.defineProperties( module.exports, {
@@ -97,116 +94,119 @@ Object.defineProperties( module.exports, {
       let path = _.get( req, 'url', null );
       let uri = referer || origin || ( 'http://' + host + path );
 
-      var cacheKey = md5(uri);
+      let cacheKey = 'getReferrer:' + uri;
 
-      myCache.get(cacheKey, function (err, urlParts) {
+      let elasticSearchCache = module.exports.getElasticSearchCache();
 
-        if (!_.isEmpty(urlParts)) {
-          debug('Retrieving referer url parts for [%s] from cache', colors.green(uri));
-          return callback(null, urlParts);
-        }
-
-        urlParts = url.parse(uri);
-
-        let firestore;
-
-        // Validate parameters and initialize Firestore
-        if(Array.isArray(params)) {
-          firestore = firebase.init('firestore', ...params);
+      elasticSearchCache.get(cacheKey).then((response) => {
+        // If cache is not empty - using it, otherwise re-request data and caching it for further requests.
+        if (_.get(response, 'data', null)) {
+          debug('Retrieving referer url parts for [%s] from cache', colors.green(cacheKey));
+          return callback(null, _.get(response, 'data'));
         } else {
-          firestore = firebase.init('firestore');
-        }
+          let urlParts = url.parse(uri);
 
-        firestore.listDocuments('brands', (err, brands)=>{
-          if(err){
-            return callback(err);
+          let firestore;
+
+          // Validate parameters and initialize Firestore
+          if (Array.isArray(params)) {
+            firestore = firebase.init('firestore', ...params);
+          } else {
+            firestore = firebase.init('firestore');
           }
 
-          // Setup domains and brands.
+          firestore.listDocuments('brands', (err, brands) => {
+            if (err) {
+              return callback(err);
+            }
 
-          var domains = _.get( config, 'rules.domains', [] );
-          domains = Array.isArray(domains) ? domains : [];
-          _.each(brands || [], brand=>{
-            _.each(['default','development'], scope=>{
-              if(_.get( brand, `domain.${scope}.main` )) {
-                domains.push(_.get( brand, `domain.${scope}.main` ));
+            // Setup domains and brands.
+
+            var domains = _.get(config, 'rules.domains', []);
+            domains = Array.isArray(domains) ? domains : [];
+            _.each(brands || [], brand => {
+              _.each(['default', 'development'], scope => {
+                if (_.get(brand, `domain.${scope}.main`)) {
+                  domains.push(_.get(brand, `domain.${scope}.main`));
+                }
+                if (_.get(brand, `domain.${scope}.mirrors`)) {
+                  domains = domains.concat(_.get(brand, `domain.${scope}.mirrors`));
+                }
+              });
+            });
+            _.set(config, "rules.domains", domains);
+            _.set(config, "brands", brands);
+
+            // Detect and Parse Referer URI.
+
+            var domains = [];
+            var urlPartsToExtract = [];
+
+            // If referer is IP, - break here, since we can not detect brand and subdomain by IP.
+            if ((_.get(urlParts, 'hostname', '')).match(/^([0-9]{1,3}\.){3}[0-9]{1,3}$/g)) {
+              return callback(null, urlParts);
+            }
+
+            var hostParts = urlParts.hostname.split('.');
+
+            _.each(_.get(config, 'rules.domains', []), function (domain) {
+              var domainParts = domain.split('.');
+              if (domainParts[0] && domains.indexOf(domainParts[0]) < 0) {
+                domains.push(domainParts[0]);
               }
-              if(_.get( brand, `domain.${scope}.mirrors` )) {
-                domains = domains.concat( _.get( brand, `domain.${scope}.mirrors` ) );
+              if (domainParts[1] && urlPartsToExtract.indexOf(domainParts[1]) < 0) {
+                urlPartsToExtract.push(domainParts[1]);
               }
             });
+
+            //Get the machine name we're targeting if we have one
+            var machineName = _.intersection(hostParts, config.rules.machines);
+            urlParts.machineName = machineName.length ? machineName[0] : false;
+
+            // Force 'https' protocol, if the request goes through Load Balancer
+            // -------------
+            // Note: we know, that, if we're not requesting machine (e.g. gc1 ) directly, request is secure (https)
+            // but, looks like Pagespeed handles scripts files with non-secure requests, so we prevent the issue here by the following check:
+            urlParts.protocol = urlParts.machineName ? urlParts.protocol : 'https:';
+
+            //Get the agent subdomain we're targeting if we have one
+            var agentSubdomain = _.difference(hostParts, config.rules.machines.concat(domains).concat(urlPartsToExtract));
+
+            //Be sure agentSubdomain does not match any of our reserved system names and if that system name is assigned an middleware
+            //i.e. kb.boxmls.com middleware OR api. logic, etc.
+            urlParts.agentSubdomain = agentSubdomain.length && agentSubdomain[0].length && config.rules.reserved_subdomains.indexOf(agentSubdomain[0]) < 0 ? agentSubdomain[0] : false;
+
+            // Detect the potential brand host;
+            urlParts.brandHost = urlParts.hostname;
+            // We allow only 2 level domain for Brand. So if there are more than two levels - just cut extra ones.
+            var brandHostParts = urlParts.brandHost.split('.');
+            if (brandHostParts.length > 2) {
+              brandHostParts = brandHostParts.slice(Math.max(brandHostParts.length - 2, 1));
+              urlParts.brandHost = brandHostParts.join('.');
+            }
+
+            let brand = (_.filter(_.get(config, 'brands'), (i) => {
+              let boolean = false;
+              _.each(['default', 'development'], scope => {
+                if (i.domain[scope].main == urlParts.brandHost || i.domain[scope].mirrors.indexOf(urlParts.brandHost) > -1) {
+                  boolean = true;
+                }
+              });
+              return boolean;
+            })).shift();
+
+            urlParts.brand = brand ? brand.uniqueID : null;
+
+            elasticSearchCache.set(cacheKey, agent, 60 * 60).then(result => {
+              debug('Successfully stored cache doc [%s]', cacheKey);
+            }, error => {
+              console.error(error);
+            });
+
+            callback(null, urlParts);
           });
-          _.set(config, "rules.domains", domains);
-          _.set(config, "brands", brands);
-
-          // Detect and Parse Referer URI.
-
-          var domains = [];
-          var urlPartsToExtract = [];
-
-          // If referer is IP, - break here, since we can not detect brand and subdomain by IP.
-          if((_.get(urlParts,'hostname','')).match(/^([0-9]{1,3}\.){3}[0-9]{1,3}$/g)) {
-            return callback( null, urlParts );
-          }
-
-          var hostParts = urlParts.hostname.split('.');
-
-          _.each( _.get( config, 'rules.domains', [] ), function( domain ) {
-            var domainParts = domain.split('.');
-            if( domainParts[0] && domains.indexOf( domainParts[0] ) < 0 ) {
-              domains.push(domainParts[0]);
-            }
-            if( domainParts[1] && urlPartsToExtract.indexOf( domainParts[1] ) < 0 ) {
-              urlPartsToExtract.push(domainParts[1]);
-            }
-          } );
-
-          //Get the machine name we're targeting if we have one
-          var machineName = _.intersection( hostParts, config.rules.machines );
-          urlParts.machineName = machineName.length ? machineName[0] : false;
-
-          // Force 'https' protocol, if the request goes through Load Balancer
-          // -------------
-          // Note: we know, that, if we're not requesting machine (e.g. gc1 ) directly, request is secure (https)
-          // but, looks like Pagespeed handles scripts files with non-secure requests, so we prevent the issue here by the following check:
-          urlParts.protocol = urlParts.machineName ? urlParts.protocol : 'https:';
-
-          //Get the agent subdomain we're targeting if we have one
-          var agentSubdomain = _.difference(hostParts, config.rules.machines.concat(domains).concat(urlPartsToExtract));
-
-          //Be sure agentSubdomain does not match any of our reserved system names and if that system name is assigned an middleware
-          //i.e. kb.boxmls.com middleware OR api. logic, etc.
-          urlParts.agentSubdomain = agentSubdomain.length && agentSubdomain[0].length && config.rules.reserved_subdomains.indexOf( agentSubdomain[0] ) < 0 ? agentSubdomain[0] : false;
-
-          // Detect the potential brand host;
-          urlParts.brandHost = urlParts.hostname;
-          // We allow only 2 level domain for Brand. So if there are more than two levels - just cut extra ones.
-          var brandHostParts = urlParts.brandHost.split('.');
-          if( brandHostParts.length > 2 ) {
-            brandHostParts = brandHostParts.slice(Math.max(brandHostParts.length - 2, 1));
-            urlParts.brandHost = brandHostParts.join('.');
-          }
-
-          let brand = (_.filter( _.get( config, 'brands' ), (i)=>{
-            let boolean = false;
-            _.each(['default','development'], scope=>{
-              if( i.domain[scope].main == urlParts.brandHost || i.domain[scope].mirrors.indexOf( urlParts.brandHost ) > -1 ) {
-                boolean = true;
-              }
-            });
-            return boolean;
-          } )).shift();
-
-          urlParts.brand = brand ? brand.uniqueID : null;
-
-          myCache.set( cacheKey, urlParts, (60*60), function(){
-            callback( null, urlParts );
-          } );
-
-        });
-
+        }
       });
-
     },
     enumerable: true,
     configurable: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxmls-utility",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "BoxMLS Common Functions Utility",
   "main": "lib/index.js",
   "scripts": {
@@ -31,10 +31,8 @@
     "html-excerpt": "^0.1.0",
     "lodash": "^4.17.15",
     "mandrill-api": "^1.0.45",
-    "md5": "^2.2.1",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.26",
-    "node-cache": "^4.2.1",
     "root-require": "^0.3.1",
     "s3": "^4.4.0",
     "slack-node": "^0.2.0",


### PR DESCRIPTION
* Replaced `node-cache` with `elasticsearch-cache` internal library for `getReferrer` request.
* Cleaned up `package.json`, removed `md5` and `node-cache` npm packages since it not using anymore.