### PR TITLE
0.6.1

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,3 +1,6 @@
+### 0.6.1
+* Added `checkIfDisabled` method to `elasticsearch-cache` library to be able to disable cache logic with `ES_CACHE_DISABLED` env.
+
 ### 0.6.0
 * Updated `elasticsearch-cache` mocha tests in terms of new functionality.
 * Updated `elasticsearch-cache` library, small fixes, added new comments, switched `console.error` to `debug`, updated `debug` messages.

--- a/lib/elasticsearch-cache.js
+++ b/lib/elasticsearch-cache.js
@@ -35,6 +35,9 @@ module.exports = class ElasticSearchCache {
       let _id;
 
       try {
+
+        this.checkIfDisabled();
+
         _id = this.buildIdHash(key);
 
         debug('cache.get:[%s] Requesting cache.', colors.green(key));
@@ -115,6 +118,9 @@ module.exports = class ElasticSearchCache {
       let _id;
 
       try {
+
+        this.checkIfDisabled();
+
         _id = this.buildIdHash(key);
 
         let _doc = {
@@ -161,6 +167,9 @@ module.exports = class ElasticSearchCache {
       let _id;
 
       try {
+
+        this.checkIfDisabled();
+
         _id = this.buildIdHash(key);
 
         debug('cache.flush:[%s] Flushing cache by ES document id.', colors.green(key));
@@ -196,6 +205,8 @@ module.exports = class ElasticSearchCache {
     return new Promise((resolve, reject) => {
 
       try {
+
+        this.checkIfDisabled();
 
         let service = _.get(process.env, 'GIT_NAME', null);
         let branch = _.get(process.env, 'GIT_BRANCH', null);
@@ -289,6 +300,20 @@ module.exports = class ElasticSearchCache {
 
       debug(err);
       throw new Error(err);
+    }
+  }
+
+  /**
+   * Checking if ES cache disabled
+   * If so, then throw new error
+   *
+   * @returns {boolean}
+   */
+  checkIfDisabled(){
+    if(_.get(process.env, 'ES_CACHE_DISABLED', false)){
+      throw new Error('cache.isEnabled: ElasticSearch cache disabled');
+    }else{
+      return true;
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxmls-utility",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "BoxMLS Common Functions Utility",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
* Added `checkIfDisabled` method to `elasticsearch-cache` library to be able to disable cache logic with `ES_CACHE_DISABLED` env.